### PR TITLE
Support OSX/Mono #14

### DIFF
--- a/Fody/Fody.csproj
+++ b/Fody/Fody.csproj
@@ -102,16 +102,14 @@
     </ItemGroup>
     <Delete Files="@(FilesToDelete)" />
     <MakeDir Directories="$(SolutionDir)NuGetBuild" />
-    <Exec Command="&quot;$(SolutionDir)Tools\ilmerge.exe&quot; /out:&quot;$(SolutionDir)NuGetBuild\Stamp.Fody.dll&quot; &quot;$(TargetDir)Stamp.Fody.dll&quot; &quot;$(TargetDir)LibGit2Sharp.dll&quot;  /target:library /targetplatform:v4" />
-    <CreateItem Include="$(TargetDir)\NativeBinaries\amd64\*.dll">
-      <Output TaskParameter="Include" ItemName="amd64" />
+    <Copy SourceFiles="$(TargetDir)Stamp.Fody.dll" DestinationFolder="$(SolutionDir)NuGetBuild\" />
+    <CreateItem Include="$(TargetDir)\NativeBinaries\**\*.*">
+      <Output TaskParameter="Include" ItemName="NativeBinaries" />
     </CreateItem>
-    <Copy SourceFiles="@(amd64)" DestinationFolder="$(SolutionDir)NuGetBuild\NativeBinaries\amd64" />
+    <Copy SourceFiles="@(NativeBinaries)" DestinationFolder="$(SolutionDir)NuGetBuild\NativeBinaries\%(RecursiveDir)" />
+    <Copy SourceFiles="$(TargetDir)LibGit2Sharp.dll" DestinationFolder="$(SolutionDir)NuGetBuild\" />
+    <Copy SourceFiles="$(TargetDir)LibGit2Sharp.dll.config" DestinationFolder="$(SolutionDir)NuGetBuild\" />
     <Copy SourceFiles="$(SolutionDir)Lib\Verpatch\verpatch.exe" DestinationFolder="$(SolutionDir)NuGetBuild\" />
-    <CreateItem Include="$(TargetDir)NativeBinaries\x86\*.dll">
-      <Output TaskParameter="Include" ItemName="x86" />
-    </CreateItem>
-    <Copy SourceFiles="@(x86)" DestinationFolder="$(SolutionDir)NuGetBuild\NativeBinaries\x86" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\Fody_ToBeDeleted.txt" DestinationFolder="$(SolutionDir)NuGetBuild\Content" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\install.ps" DestinationFiles="$(SolutionDir)NuGetBuild\Tools\install.ps1" />
     <Copy SourceFiles="$(ProjectDir)NugetAssets\uninstall.ps" DestinationFiles="$(SolutionDir)NuGetBuild\Tools\uninstall.ps1" />

--- a/Fody/ModuleWeaver.cs
+++ b/Fody/ModuleWeaver.cs
@@ -171,6 +171,13 @@ public class ModuleWeaver
         {
             return;
         }
+        
+        if (Environment.OSVersion.Platform == PlatformID.Unix || 
+            Environment.OSVersion.Platform == PlatformID.MacOSX)
+        {
+            return;
+        }
+        
         var verPatchPath = Path.Combine(AddinDirectoryPath, "verpatch.exe");
         var arguments = $"\"{AssemblyFilePath}\" /pv \"{assemblyInfoVersion}\" /high {assemblyVersion}";
         LogInfo($"Patching version using: {verPatchPath} {arguments}");


### PR DESCRIPTION
- Bundle native dependencies on all platforms to the nuget package.
- Do not ilmerge LibSharp2Git so the native dependencies can be loaded correctly.
- Do not run verpatch.exe on linux and mac